### PR TITLE
Implement void summon with svg characters

### DIFF
--- a/assets/sprites/characters/bruno.svg
+++ b/assets/sprites/characters/bruno.svg
@@ -1,1 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64"><rect width="64" height="64" rx="10" fill="#2b3b52"/><circle cx="32" cy="32" r="18" fill="#8ecae6"/><text x="32" y="38" font-size="16" text-anchor="middle" fill="#0e1a2b">B</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="14" fill="#0e1a2b"/>
+  <g stroke="#ffd166" stroke-width="6" stroke-linecap="round" fill="none">
+    <circle cx="64" cy="36" r="12" fill="#ffd166" stroke="none"/>
+    <line x1="64" y1="48" x2="64" y2="92"/>
+    <line x1="64" y1="58" x2="46" y2="70"/>
+    <line x1="64" y1="58" x2="86" y2="68"/>
+    <line x1="64" y1="92" x2="50" y2="112"/>
+    <line x1="64" y1="92" x2="78" y2="112"/>
+    <!-- staff with cross in right hand -->
+    <line x1="86" y1="68" x2="86" y2="104"/>
+    <line x1="78" y1="80" x2="94" y2="80"/>
+  </g>
+  <!-- subtle aura -->
+  <circle cx="64" cy="36" r="18" fill="none" stroke="#ffe9a8" stroke-opacity="0.35" stroke-width="4"/>
+</svg>

--- a/assets/sprites/characters/er1ze.svg
+++ b/assets/sprites/characters/er1ze.svg
@@ -1,1 +1,18 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64"><rect width="64" height="64" rx="10" fill="#0b2538"/><circle cx="32" cy="32" r="18" fill="#34d399"/><text x="32" y="38" font-size="16" text-anchor="middle" fill="#0e1a2b">E</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="14" fill="#071824"/>
+  <!-- square robot head -->
+  <rect x="54" y="24" width="20" height="20" rx="3" fill="#34d399"/>
+  <!-- antenna -->
+  <line x1="64" y1="24" x2="64" y2="16" stroke="#34d399" stroke-width="4"/>
+  <circle cx="64" cy="14" r="3" fill="#34d399"/>
+  <g stroke="#34d399" stroke-width="6" stroke-linecap="round" fill="none">
+    <line x1="64" y1="48" x2="64" y2="92"/>
+    <line x1="64" y1="58" x2="46" y2="72"/>
+    <line x1="64" y1="58" x2="82" y2="72"/>
+    <line x1="64" y1="92" x2="50" y2="112"/>
+    <line x1="64" y1="92" x2="78" y2="112"/>
+  </g>
+  <!-- eyes -->
+  <rect x="58" y="30" width="4" height="4" fill="#0e1a2b"/>
+  <rect x="66" y="30" width="4" height="4" fill="#0e1a2b"/>
+</svg>

--- a/assets/sprites/characters/shadow.svg
+++ b/assets/sprites/characters/shadow.svg
@@ -1,1 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64"><rect width="64" height="64" rx="10" fill="#111827"/><circle cx="32" cy="32" r="18" fill="#374151"/><text x="32" y="38" font-size="16" text-anchor="middle" fill="#e5e7eb">S</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="14" fill="#0a0f1a"/>
+  <g stroke="#374151" stroke-width="6" stroke-linecap="round" fill="none" opacity="0.9">
+    <circle cx="64" cy="36" r="12" fill="#111827" stroke="#111827"/>
+    <line x1="64" y1="48" x2="64" y2="92"/>
+    <line x1="64" y1="58" x2="46" y2="68"/>
+    <line x1="64" y1="58" x2="82" y2="70"/>
+    <line x1="64" y1="92" x2="50" y2="112"/>
+    <line x1="64" y1="92" x2="78" y2="112"/>
+  </g>
+  <!-- shadow wisp -->
+  <g fill="none" stroke="#8a7aff" stroke-opacity="0.25" stroke-width="3">
+    <path d="M20,100 C40,80 60,84 80,90"/>
+    <path d="M30,92 C52,76 70,78 94,86"/>
+  </g>
+</svg>

--- a/assets/sprites/characters/vampire.svg
+++ b/assets/sprites/characters/vampire.svg
@@ -1,1 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64"><rect width="64" height="64" rx="10" fill="#3b0d0c"/><circle cx="32" cy="28" r="16" fill="#ef4444"/><path d="M24 44 L32 52 L40 44" stroke="#ef4444" stroke-width="3" fill="none"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="14" fill="#1a0b0b"/>
+  <!-- cape -->
+  <path d="M40 60 C50 90, 78 90, 88 60 L64 48 Z" fill="#ef4444" fill-opacity="0.5"/>
+  <g stroke="#ef4444" stroke-width="6" stroke-linecap="round" fill="none">
+    <circle cx="64" cy="36" r="12" fill="#ef4444" stroke="none"/>
+    <line x1="64" y1="48" x2="64" y2="92"/>
+    <line x1="64" y1="58" x2="46" y2="70"/>
+    <line x1="64" y1="58" x2="82" y2="70"/>
+    <line x1="64" y1="92" x2="50" y2="112"/>
+    <line x1="64" y1="92" x2="78" y2="112"/>
+  </g>
+  <!-- fangs -->
+  <polygon points="60,42 62,48 58,48" fill="#ffffff"/>
+  <polygon points="68,42 70,48 66,48" fill="#ffffff"/>
+</svg>

--- a/assets/sprites/characters/x.svg
+++ b/assets/sprites/characters/x.svg
@@ -1,1 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64"><rect width="64" height="64" rx="10" fill="#1f2937"/><circle cx="32" cy="32" r="18" fill="#60a5fa"/><text x="32" y="38" font-size="16" text-anchor="middle" fill="#0e1a2b">X</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="14" fill="#0e1320"/>
+  <g stroke="#a78bfa" stroke-width="6" stroke-linecap="round" fill="none">
+    <circle cx="64" cy="36" r="12" fill="#a78bfa" stroke="none"/>
+    <line x1="64" y1="48" x2="64" y2="92"/>
+    <line x1="64" y1="58" x2="46" y2="68"/>
+    <line x1="64" y1="58" x2="82" y2="68"/>
+    <line x1="64" y1="92" x2="50" y2="112"/>
+    <line x1="64" y1="92" x2="78" y2="112"/>
+    <!-- staff with star -->
+    <line x1="82" y1="68" x2="82" y2="102"/>
+  </g>
+  <polygon points="54,30 74,30 64,14" fill="#7c3aed"/>
+  <g fill="#fde68a" stroke="#fde68a" stroke-width="2">
+    <polygon points="82,60 86,66 94,66 88,72 90,80 82,76 74,80 76,72 70,66 78,66"/>
+  </g>
+</svg>

--- a/assets/sprites/characters/zeus.svg
+++ b/assets/sprites/characters/zeus.svg
@@ -1,1 +1,13 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64"><rect width="64" height="64" rx="10" fill="#0a1b2e"/><polygon points="28,10 36,10 30,28 40,28 24,54 30,34 22,34" fill="#fcd34d"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="14" fill="#0a1421"/>
+  <g stroke="#fcd34d" stroke-width="6" stroke-linecap="round" fill="none">
+    <circle cx="64" cy="36" r="12" fill="#fcd34d" stroke="none"/>
+    <line x1="64" y1="48" x2="64" y2="92"/>
+    <line x1="64" y1="58" x2="46" y2="68"/>
+    <line x1="64" y1="58" x2="84" y2="68"/>
+    <line x1="64" y1="92" x2="50" y2="112"/>
+    <line x1="64" y1="92" x2="78" y2="112"/>
+  </g>
+  <!-- lightning bolt in right hand -->
+  <polygon points="84,60 72,78 82,78 70,96 92,74 82,74" fill="#fde68a"/>
+</svg>

--- a/src/scenes/VoidSummonScene.js
+++ b/src/scenes/VoidSummonScene.js
@@ -22,16 +22,9 @@ export class VoidSummonScene extends Phaser.Scene {
 
   _infoText() {
     const s = window.PathHeroesState.data;
-    const lines = [];
-    lines.push(`Пустотных свитков: ${formatStat(s.voidScrolls || 0)}`);
-    lines.push('Список (шансы и характеристики):');
-    lines.push(`- ${CHARACTERS.bruno.name} — Пастор, Здоровье: 9000, Урон: 500, Скорость атаки: 1/сек, Шанс: ${VOID_SUMMON_CHANCES.bruno}%`);
-    lines.push(`- ${CHARACTERS.shadow.name} — Тень, Здоровье: 10000, Урон: 450, Скорость атаки: 1/сек, Шанс: ${VOID_SUMMON_CHANCES.shadow}%, Способность: может быть атакован только когда все другие персонажи игрока мертвы`);
-    lines.push(`- ${CHARACTERS.x.name} — Маг, Здоровье: 11000, Урон: 700, Скорость атаки: 2/сек, Шанс: ${VOID_SUMMON_CHANCES.x}%, Способность: каждые 2 сек. блокирует случайного монстра на 2 сек.`);
-    lines.push(`- ${CHARACTERS.vampire.name} — Нежить, Здоровье: 15000, Урон: 1500, Скорость атаки: 1/сек, Шанс: ${VOID_SUMMON_CHANCES.vampire}%, Способность: 50% шанс восстановить 20% здоровья при ударе`);
-    lines.push(`- ${CHARACTERS.er1ze.name} — Робот, Здоровье: 12000, Урон: 1000, Скорость атаки: 1/сек, Шанс: ${VOID_SUMMON_CHANCES.er1ze}%, Способность: 10% шанс нанести дополнительно 6000 урона`);
-    lines.push(`- ${CHARACTERS.zeus.name} — Бог, Здоровье: 25000, Урон: 1500, Скорость атаки: 2/сек, Шанс: ${VOID_SUMMON_CHANCES.zeus}%, Способность: каждые 2 сек. увеличивает свой урон на 200`);
-    return lines.join('\n');
+    // Only show percentages for void summon
+    return `Пустотных свитков: ${formatStat(s.voidScrolls || 0)}\nШансы (пустотный):\n` +
+      VOID_SUMMON_ORDER.map(id => `${CHARACTERS[id].name}: ${VOID_SUMMON_CHANCES[id]}%`).join('\n');
   }
 
   refresh() {


### PR DESCRIPTION
Adds a new Void Summon feature with unique character SVGs and a simplified chance display.

---
<a href="https://cursor.com/background-agent?bcId=bc-9ba97a0c-56ba-45dd-ae11-4d957129865d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9ba97a0c-56ba-45dd-ae11-4d957129865d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

