### PR TITLE
Fix void scroll character inventory bug

### DIFF
--- a/src/scenes/InventoryScene.js
+++ b/src/scenes/InventoryScene.js
@@ -1,4 +1,4 @@
-import { CHARACTERS, CHARACTER_ORDER, makeTextButton, formatStat } from '../utils.js';
+import { CHARACTERS, INVENTORY_ORDER, makeTextButton, formatStat } from '../utils.js';
 import { music } from '../music.js';
 
 export class InventoryScene extends Phaser.Scene {
@@ -25,7 +25,7 @@ export class InventoryScene extends Phaser.Scene {
   buildFlatList() {
     // Expand to instances: [ {charId, instanceIndex} ]
     this.flat = [];
-    for (const id of CHARACTER_ORDER) {
+    for (const id of INVENTORY_ORDER) {
       const arr = window.PathHeroesState.getInstances(id);
       for (let k = 0; k < arr.length; k++) this.flat.push({ id, idx: k });
     }

--- a/src/scenes/PrepareScene.js
+++ b/src/scenes/PrepareScene.js
@@ -1,4 +1,4 @@
-import { CHARACTERS, CHARACTER_ORDER, makeTextButton, formatStat, generateMonsterTeam } from '../utils.js';
+import { CHARACTERS, INVENTORY_ORDER, makeTextButton, formatStat, generateMonsterTeam } from '../utils.js';
 
 export class PrepareScene extends Phaser.Scene {
   constructor() { super('Prepare'); }
@@ -55,7 +55,7 @@ export class PrepareScene extends Phaser.Scene {
 
   buildFlatList() {
     this.flat = [];
-    for (const id of CHARACTER_ORDER) {
+    for (const id of INVENTORY_ORDER) {
       const arr = window.PathHeroesState.getInstances(id);
       for (let idx = 0; idx < arr.length; idx++) this.flat.push({ id, idx });
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -45,6 +45,12 @@ export const VOID_SUMMON_CHANCES = {
   zeus: 3,
 };
 
+// Inventory display order: base characters first, then unique void characters
+export const INVENTORY_ORDER = [
+  ...CHARACTER_ORDER,
+  ...VOID_SUMMON_ORDER.filter((id) => !CHARACTER_ORDER.includes(id)),
+];
+
 export function cloneDeep(obj) {
   return JSON.parse(JSON.stringify(obj));
 }


### PR DESCRIPTION
Fixes void-summoned characters not appearing in inventory or team selection by using a combined inventory order.

---
<a href="https://cursor.com/background-agent?bcId=bc-36b52550-37f1-43ed-b41a-9949c232782d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-36b52550-37f1-43ed-b41a-9949c232782d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

